### PR TITLE
Create apparmor profile if one doesn't exist (re: Ubuntu 24.04)

### DIFF
--- a/files/apptainer
+++ b/files/apptainer
@@ -1,0 +1,9 @@
+# Permit unprivileged user namespace creation for apptainer starter
+abi <abi/4.0>,
+include <tunables/global>
+profile apptainer /usr/libexec/apptainer/bin/starter{,-suid}
+    flags=(unconfined) {
+  userns,
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/apptainer>
+}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Reload apparmor
+  service:
+    name: apparmor
+    state: reloaded

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,3 +20,14 @@
   ansible.builtin.package:
     name: apptainer
   when: ansible_distribution == "Ubuntu" or ansible_os_family == "RedHat"
+
+# Required for Ubuntu 23.10+ when apptainer is installed from Ubuntu PPA
+# Ref: https://github.com/apptainer/apptainer/issues/2691#issuecomment-2610689935
+# Ref: https://github.com/apptainer/apptainer/blob/main/INSTALL.md#apparmor-profile-ubuntu-2310
+- name: Create apparmor profile if one doesn't exist
+  copy:
+    src: apptainer
+    dest: /etc/apparmor.d/apptainer
+    force: false
+  notify: 'Reload apparmor'
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'noble'


### PR DESCRIPTION
Fixes #1
Tested on 24.04.1 LTS server.

The problem is that when installed from Ubuntu PPA, the apptainer apparmor profile file is not created, which is required for Ubuntu 23.10+ 

See for more context:
https://github.com/apptainer/apptainer/issues/2691#issuecomment-2610689935
https://github.com/apptainer/apptainer/blob/main/INSTALL.md#apparmor-profile-ubuntu-2310