### PR TITLE
Use ansible-core instead of ansible-base

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Ansible.
-        run: pip3 install ansible-base
+        run: pip3 install ansible-core
 
       - name: Trigger a new import on Galaxy.
         run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2) --branch main

--- a/.github/workflows/slugger.yml
+++ b/.github/workflows/slugger.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Ansible.
-        run: pip3 install ansible-base
+        run: pip3 install ansible-core
 
       - name: Check for changes
         run: |


### PR DESCRIPTION
Fixes broken github action: https://github.com/usegalaxy-eu/ansible-apptainer/actions/runs/14249654918/job/39939154399#step:5:15

ansible-base is EOL as of 5/23/2022, does not support Python 3.10+ ([ref](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix)); workflow runs on Python 3.13.

xref https://github.com/galaxyproject/ansible-cvmfs/pull/76